### PR TITLE
Allow `Map` to have a different resulting kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+Breaking changes:
+
+New features:
+* Allowed `Map` operations to have a different resulting kind.
+* Replaced the `func` type variable in `Map` with a higher-kinded type `(k -> l)`.
+
+Bugfixes:
+
+Other improvements:
+
 ## [2.0.0] - BREAKING!
 ### Added
 * The `k` parameter for `List'`, enforcing homogeneity of kinds.

--- a/src/Type/Data/List.purs
+++ b/src/Type/Data/List.purs
@@ -229,7 +229,7 @@ else instance zipRec
 
 
 -- | Maps a type constructor to a `List'`.
-class Map :: forall func k l. func -> List' k -> List' l -> Constraint
+class Map :: forall k l. (k -> l) -> List' k -> List' l -> Constraint
 class Map f xs ys | f xs -> ys where
   map :: forall fproxy kproxy lproxy. fproxy f -> kproxy xs -> lproxy ys
 

--- a/src/Type/Data/List.purs
+++ b/src/Type/Data/List.purs
@@ -229,9 +229,9 @@ else instance zipRec
 
 
 -- | Maps a type constructor to a `List'`.
-class Map :: forall func k. func -> List' k -> List' k -> Constraint
+class Map :: forall func k l. func -> List' k -> List' l -> Constraint
 class Map f xs ys | f xs -> ys where
-  map :: forall fproxy lproxy. fproxy f -> lproxy xs -> lproxy ys
+  map :: forall fproxy kproxy lproxy. fproxy f -> kproxy xs -> lproxy ys
 
 
 instance mapNil :: Map f Nil' Nil' where

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -15,6 +15,11 @@ import Type.Data.Peano as P
 import Type.Prelude (Proxy(..))
 
 
+data Literals
+
+foreign import data LiteralSymbol :: Symbol -> Literals
+
+
 spec :: Spec Unit
 spec = do
   let xs = Proxy :: _ ( Int :> Char :> Nil' )
@@ -102,6 +107,10 @@ spec = do
     it "transforms a non-empty list" do
       let r = Proxy :: _ ( Array Int :> Array Char :> Nil' )
       TL.map ( Proxy :: _ Array ) xs `shouldEqual` r
+    it "allows mapping into another kind" do
+      let k = Proxy :: _ ( "hello" :> Nil' )
+          l = Proxy :: _ ( LiteralSymbol "hello" :> Nil' )
+      TL.map ( Proxy :: _ LiteralSymbol ) k `shouldEqual` l
 
   let f = ( Proxy :: _ Tuple )
       a = ( Proxy :: _ String )


### PR DESCRIPTION
e.g. this compiles successfully now
```purescript
module Example where

import Type.Data.List as TL

data TypeExpr

foreign import data LiteralSymbol :: Symbol -> TypeExpr

f :: Proxy (LiteralSymbol "hello" :> Nil')
f = TL.map (Proxy :: _ LiteralSymbol) (Proxy :: _ ("hello" :> Nil'))
```