### PR TITLE
Fix license identifier in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,5 +7,5 @@
   },
   "repository": "git@github.com:PureFunctor/purescript-typelevel-lists.git",
   "author": "PureFunctor <purefunctor@gmail.com>",
-  "license": "BSD-3-License"
+  "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
This PR fixes the license identifier listed in the `package.json` to be a valid SPDX identifier.

### Motivation

`typelevel-lists` is currently in the PureScript [package set](https://github.com/purescript/package-sets) and will need to have this license issue addressed in order to remain in the package set after the move to the new PureScript registry.

See https://github.com/purescript/registry/issues/250 for more details.